### PR TITLE
Abstract REST Client into a new parent

### DIFF
--- a/class-wp-rest-request.php
+++ b/class-wp-rest-request.php
@@ -1,0 +1,72 @@
+<?php
+
+class WP_REST_Request {
+	private $url;
+	private $method;
+	private $params = array();
+	private $post_data = array();
+	private $headers = array();
+	private $is_multipart = false;
+
+	public function __construct( $url, $method, $post_data = array(), $headers = array(), $is_multipart = false ) {
+		$this->url = $url;
+		$this->method = $method;
+		$this->set_headers( $headers );
+		$this->set_post_data( $post_data );
+		$this->set_is_multipart( $is_multipart );
+	}
+
+	public function get_url() {
+		return $this->url;
+	}
+
+	public function get_method() {
+		return $this->method;
+	}
+
+	public function set_post_data( $post_data ) {
+		$this->post_data = $post_data;
+	}
+
+	public function has_post_data() {
+		return ! empty( $this->post_data );
+	}
+
+	public function get_post_data() {
+		return $this->post_data;
+	}
+
+	public function set_headers( $headers ) {
+		$this->headers = array();
+		foreach ( $headers as $name => $content ) {
+			$this->add_header( $name, $content );
+		}
+	}
+
+	public function add_header( $name, $content ) {
+		$this->headers[ $name ] = $content;
+	}
+
+	public function get_headers() {
+		return $this->headers;
+	}
+
+	public function get_processed_headers() {
+		$processed_headers = array();
+
+		foreach ( $this->headers as $name => $content ) {
+			$processed_headers[] = sprintf( '%s: %s', $name, $content );
+		}
+
+		return $processed_headers;
+	}
+
+	public function set_is_multipart( $is_multipart ) {
+		$this->is_multipart = $is_multipart;
+		$this->add_header( 'Content-Type', 'multipart/form-data' );
+	}
+
+	public function is_multipart() {
+		return $this->is_multipart;
+	}
+}

--- a/class-wpcom-rest-client.php
+++ b/class-wpcom-rest-client.php
@@ -2,6 +2,7 @@
 
 // TODO: replace with spl-autoload?
 $base_dir =  dirname( __FILE__ );
+require_once( $base_dir . '/class-wp-rest-client.php' );
 require_once( $base_dir . '/class-wpcom-rest-exception.php' );
 require_once( $base_dir . '/class-wpcom-rest-transport.php' );
 require_once( $base_dir . '/class-wpcom-rest-transport-curl.php' );
@@ -12,10 +13,7 @@ require_once( $base_dir . '/class-wpcom-rest-object-post.php' );
 require_once( $base_dir . '/class-wpcom-rest-object-me.php' );
 unset( $base_dir );
 
-class WPCOM_Rest_Client {
-	const REQUEST_METHOD_GET = 'GET';
-	const REQUEST_METHOD_POST = 'POST';
-
+class WPCOM_Rest_Client extends WP_REST_Client {
 	const OAUTH_ACCESS_TOKEN_ENDPOINT = '/token';
 	const OAUTH_AUTHORIZE_ENDPOINT = '/authorize';
 	const OAUTH_AUTHENTICATE_URL = '/authenticate';
@@ -23,33 +21,14 @@ class WPCOM_Rest_Client {
 	const DEFAULT_API_BASE_URL = 'https://public-api.wordpress.com/rest';
 	const DEFAULT_OAUTH_BASE_URL = 'https://public-api.wordpress.com/oauth2';
 
-	private $request_methods = array( self::REQUEST_METHOD_GET, self::REQUEST_METHOD_POST );
+	protected $request_methods = array( self::REQUEST_METHOD_GET, self::REQUEST_METHOD_POST );
 
-	private $api_transport;
 	private $oauth_base_url = self::DEFAULT_OAUTH_BASE_URL;
-	private $api_base_url = self::DEFAULT_API_BASE_URL;
+	protected $api_base_url = self::DEFAULT_API_BASE_URL;
 
 	private $auth_key;
 	private $auth_secret;
 	private $auth_token;
-
-	public function __construct() {
-		$this->set_api_transport( new WPCOM_REST_Transport_Curl ); 
-	}
-	
-	public function set_api_transport( WPCOM_REST_Transport $transport ) {
-		$this->api_transport = $transport;
-	}
-	public function get_api_transport() {
-		return $this->api_transport;
-	}
-
-	public function set_api_base_url( $url ) {
-		$this->api_base_url = $url;
-	}
-	public function get_api_base_url() {
-		return $this->api_base_url;
-	}
 
 	public function set_oauth_base_url( $url ) {
 		$this->oauth_base_url = $url;
@@ -76,55 +55,15 @@ class WPCOM_Rest_Client {
 		return $this->auth_token;
 	}
 
-	public function send_api_request( $path, $method, $params = array(), $post_data = array(), $headers = array(), $is_multipart = false ) {
-		$url = $this->build_url( $this->api_base_url, $path, $params );
-
-		if ( $this->auth_token ) { 
-			$headers[] = sprintf( 'Authorization: Bearer %s', $this->auth_token );
-		}
-
-		return $this->send_request( $url, $method, $params, $post_data, $headers, $is_multipart );
-	}
-
-	private function send_request( $url, $method, $params = array(), $post_data = array(), $headers = array(), $is_multipart = false ) {
-
-		if ( ! $this->is_valid_request_method( $method ) ) {
-			throw new DomainException( sprintf( 'Invalid request $method: %s; should be one of %s', $method, implode( ',', $this->get_valid_request_methods() ) ) );
-		}
-
+	protected function authenticate_request( $url, $method, $params, $post_data, $headers, $is_multipart ) {
+		// TODO: does not work yet, since we need to pass-by-reference
 		if ( ! is_array( $headers ) ) {
 			$headers = array();
 		}
 
-		if ( $is_multipart ) {
-			$headers[] = 'Content-Type: multipart/form-data';
-		}
-
-		// TODO: set UA to identify requests
-
-		return $this->api_transport->send_request( $url, $method, $post_data, $headers );
-	}
-
-	private function build_url( $url, $path, $params ) {
-		if ( $path ) {
-			$url = sprintf( '%s/%s', rtrim( $url, '/\\' ), ltrim( $path, '/\\' ) );
-		}
-
-		if ( ! parse_url( $url, PHP_URL_QUERY ) ) {
-			$url .= '?';
-		}
-
-		$url .= http_build_query( $params );
-
-		return $url; 
-	}
-
-	private function is_valid_request_method( $method ) {
-		return in_array( $method, $this->get_valid_request_methods() );
-	}
-
-	private function get_valid_request_methods() {
-		return $this->request_methods;
+		if ( $this->auth_token ) { 
+			$headers[] = sprintf( 'Authorization: Bearer %s', $this->auth_token );
+		}		
 	}
 
 	public function request_access_token( $authorization_code, $redirect_uri ) {

--- a/class-wpcom-rest-client.php
+++ b/class-wpcom-rest-client.php
@@ -3,6 +3,7 @@
 // TODO: replace with spl-autoload?
 $base_dir =  dirname( __FILE__ );
 require_once( $base_dir . '/class-wp-rest-client.php' );
+require_once( $base_dir . '/class-wp-rest-request.php' );
 require_once( $base_dir . '/class-wpcom-rest-exception.php' );
 require_once( $base_dir . '/class-wpcom-rest-transport.php' );
 require_once( $base_dir . '/class-wpcom-rest-transport-curl.php' );
@@ -55,15 +56,10 @@ class WPCOM_Rest_Client extends WP_REST_Client {
 		return $this->auth_token;
 	}
 
-	protected function authenticate_request( $url, $method, $params, $post_data, $headers, $is_multipart ) {
-		// TODO: does not work yet, since we need to pass-by-reference
-		if ( ! is_array( $headers ) ) {
-			$headers = array();
-		}
-
+	protected function authenticate_request( WP_REST_Request &$request ) {
 		if ( $this->auth_token ) { 
-			$headers[] = sprintf( 'Authorization: Bearer %s', $this->auth_token );
-		}		
+			$request->add_header( 'Authorization', sprintf( 'Bearer %s', $this->auth_token ) );
+		}
 	}
 
 	public function request_access_token( $authorization_code, $redirect_uri ) {
@@ -75,7 +71,9 @@ class WPCOM_Rest_Client extends WP_REST_Client {
 			'grant_type'    => 'authorization_code'
 		);
 
-		return $this->send_request( $this->oauth_base_url, OAUTH_ACCESS_TOKEN_ENDPOINT, self::REQUEST_METHOD_POST, null, $post_data, false );
+		$request = new WP_REST_Request( $this->oauth_base_url, OAUTH_ACCESS_TOKEN_ENDPOINT, self::REQUEST_METHOD_POST, null, $post_data );
+
+		return $this->send_request( $request );
 	}
 
 	public function get_blog_auth_url( $blog_url, $redirect_uri ) {

--- a/class-wpcom-rest-client.php
+++ b/class-wpcom-rest-client.php
@@ -23,7 +23,7 @@ class WPCOM_Rest_Client {
 	const DEFAULT_API_BASE_URL = 'https://public-api.wordpress.com/rest';
 	const DEFAULT_OAUTH_BASE_URL = 'https://public-api.wordpress.com/oauth2';
 
-	private $request_methods = array( 'GET', 'POST' );
+	private $request_methods = array( self::REQUEST_METHOD_GET, self::REQUEST_METHOD_POST );
 
 	private $api_transport;
 	private $oauth_base_url = self::DEFAULT_OAUTH_BASE_URL;
@@ -124,7 +124,7 @@ class WPCOM_Rest_Client {
 	}
 
 	private function get_valid_request_methods() {
-		return array( self::REQUEST_METHOD_GET, self::REQUEST_METHOD_POST );
+		return $this->request_methods;
 	}
 
 	public function request_access_token( $authorization_code, $redirect_uri ) {

--- a/class-wpcom-rest-client.php
+++ b/class-wpcom-rest-client.php
@@ -89,7 +89,7 @@ class WPCOM_Rest_Client {
 	private function send_request( $url, $method, $params = array(), $post_data = array(), $headers = array(), $is_multipart = false ) {
 
 		if ( ! $this->is_valid_request_method( $method ) ) {
-			throw new DomainException( sprintf( 'Invalid request $method: %s; should be one of %s', $method, implode( ',', $this->request_methods ) ) );
+			throw new DomainException( sprintf( 'Invalid request $method: %s; should be one of %s', $method, implode( ',', $this->get_valid_request_methods() ) ) );
 		}
 
 		if ( ! is_array( $headers ) ) {

--- a/class-wpcom-rest-transport-curl.php
+++ b/class-wpcom-rest-transport-curl.php
@@ -2,20 +2,18 @@
 
 class WPCOM_REST_Transport_Curl extends WPCOM_REST_Transport {
 
-	public function send_request( $url, $method, $post_data = array(), $headers = array() ) {
-		$curl = curl_init( $url );
+	public function send_request( WP_REST_Request $request ) {
+		$curl = curl_init( $request->get_url() );
 
 		curl_setopt( $curl, CURLOPT_RETURNTRANSFER, true );
 		curl_setopt( $curl, CURLOPT_FAILONERROR, false );
+		curl_setopt( $curl, CURLOPT_CUSTOMREQUEST, $request->get_method() );
 
-		if ( ! empty( $post_data ) ) {
-			curl_setopt( $curl, CURLOPT_POST, 1 );
-			curl_setopt( $curl, CURLOPT_POSTFIELDS, $post_data );
+		if ( $request->has_post_data() ) {
+			curl_setopt( $curl, CURLOPT_POSTFIELDS, $request->get_post_data() );
 		}
 
-		if ( ! empty( $headers ) ) {
-			curt_setopt( $curl, CURLOPT_HTTPHEADER, $headers );
-		}
+		curl_setopt( $curl, CURLOPT_HTTPHEADER, $request->get_processed_headers() );
 
 		$response = curl_exec( $curl );
 		$info     = curl_getinfo( $curl );

--- a/class-wpcom-rest-transport-wp-http-api.php
+++ b/class-wpcom-rest-transport-wp-http-api.php
@@ -8,16 +8,16 @@ class WPCOM_REST_Transport_WP_HTTP_API extends WPCOM_REST_Transport {
 		}
 	}
 
-	public function send_request( $url, $method, $post_data = array(), $headers = array() ) {
+	public function send_request( WP_REST_Request $request ) {
 		$args = array(
-			'body' => $post_data,
-			'headers' => $headers,
+			'body' => $request->get_post_data(),
+			'headers' => $request->get_processed_headers(),
 		);
 
 		if ( WPCOM_REST_Client::REQUEST_METHOD_GET === $method ) {
-			$response = wp_remote_get( $url, $args );
+			$response = wp_remote_get( $request->get_url(), $args );
 		} elseif ( WPCOM_REST_Client::REQUEST_METHOD_POST === $method ) {
-			$response = wp_remote_post( $url, $args );
+			$response = wp_remote_post( $request->get_url(), $args );
 		}
 
 		$response_code = wp_remote_retrieve_response_code( $response ); 

--- a/class-wpcom-rest-transport.php
+++ b/class-wpcom-rest-transport.php
@@ -3,7 +3,7 @@
 abstract class WPCOM_REST_Transport {
 	private $response_codes = array( 200, 301, 302 );	
 
-	abstract public function send_request( $url, $method, $post_data = array(), $headers = array() );
+	abstract public function send_request( WP_REST_Request $request );
 
 	protected function handle_success( $body ) {
 		$decoded_body = json_decode( $body );


### PR DESCRIPTION
We can extend this parent to handle both the WPCOM and WP-API APIs. Abstract some of the request handling into a separate class as well to simplify how clients deal with requests.
