### PR TITLE
set default $args in get_blog_auth_url()

### DIFF
--- a/src/class-wpcom-rest-client.php
+++ b/src/class-wpcom-rest-client.php
@@ -63,7 +63,7 @@ class WPCOM_Rest_Client extends WP_REST_Client {
 		return $this->send_request( $request );
 	}
 
-	public function get_blog_auth_url( $blog_url, $redirect_uri, $args ) {
+	public function get_blog_auth_url( $blog_url, $redirect_uri, $args=[] ) {
 		if ( empty( $this->auth_key ) ) {
 			throw new BadMethodCallException( 'Please specify a valid auth_key.' );
 		}


### PR DESCRIPTION
set default $args in get_blog_auth_url() to avoid error using the example from README.md